### PR TITLE
Add parsing of region header

### DIFF
--- a/QuickMCA/.idea/gradle.xml
+++ b/QuickMCA/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/QuickMCA/src/main/kotlin/Main.kt
+++ b/QuickMCA/src/main/kotlin/Main.kt
@@ -1,7 +1,6 @@
-fun main(args: Array<String>) {
-	println("Hello World!")
+import java.io.File
+import mca.IORegion
 
-	// Try adding program arguments via Run/Debug configuration.
-	// Learn more about running applications: https://www.jetbrains.com/help/idea/running-applications.html.
-	println("Program arguments: ${args.joinToString()}")
+fun main(args: Array<String>) {
+	IORegion.readRegion(File("world/region/r.-1.-1.mca"))
 }

--- a/QuickMCA/src/main/kotlin/Main.kt
+++ b/QuickMCA/src/main/kotlin/Main.kt
@@ -1,6 +1,22 @@
 import java.io.File
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import mca.IORegion
 
 fun main(args: Array<String>) {
-	IORegion.readRegion(File("world/region/r.-1.-1.mca"))
+	val executor = Executors.newFixedThreadPool(12)
+
+	val startTime = System.currentTimeMillis()
+	File("world/region").listFiles()
+		?.forEach {
+			executor.execute {
+				IORegion.readRegion(it)
+			}
+		}
+
+	executor.shutdown()
+	executor.awaitTermination(1, TimeUnit.MINUTES)
+
+	val endTime = System.currentTimeMillis()
+	println("Time: ${endTime - startTime}ms")
 }

--- a/QuickMCA/src/main/kotlin/mca/Chunk.kt
+++ b/QuickMCA/src/main/kotlin/mca/Chunk.kt
@@ -1,0 +1,5 @@
+package mca
+
+
+
+class Chunk {}

--- a/QuickMCA/src/main/kotlin/mca/IORegion.kt
+++ b/QuickMCA/src/main/kotlin/mca/IORegion.kt
@@ -1,0 +1,66 @@
+package mca
+
+import java.io.File
+import java.io.IOException
+import java.io.RandomAccessFile
+import util.readByteAsInt
+
+/**
+ * Performs read and write operations of region files (r.X.Y.mca)
+ */
+object IORegion {
+
+	fun readRegion(regionFile: File): Region {
+		if (regionFile.isDirectory)
+			throw IllegalArgumentException("File is can't be a directory")
+		if (!regionFile.name.endsWith(".mca"))
+			throw IllegalArgumentException("The file must end with '.mca' !")
+
+		val (rPosX, rPosY) = regionPositionFromName(regionFile.name)
+
+		RandomAccessFile(regionFile, "r").use { inputFile ->
+			// --- Get Data from header
+
+			// Retrieve chunk offsets
+			val headerData = loadHeader(inputFile)
+		}
+
+
+		return Region(rPosX, rPosY)
+	}
+
+	data class HeaderData(val offset: IntArray)
+
+	/**
+	 * Reads the header of a region file. The header contains the offset of each chunk in the file.
+	 * The offset represents the position of the chunk in the file.
+	 */
+	private fun loadHeader(file: RandomAccessFile): HeaderData {
+		val offsets = IntArray(CHUNKS_IN_REGION)
+
+		// Move to beginning of region file
+		file.seek(0)
+
+		// Read the 1024 chunks, which consist of 4 byte each
+		for(i in offsets.indices) {
+			var offset: Int = file.readByteAsInt() shl 16 // Read and shift 16 bit to the left
+			offset = offset or (file.readByteAsInt() shl 8) // Read and shift 8 bit to the left
+			offsets[i] = offset or (file.readByteAsInt()) // Just rea, no shift
+
+			val sector = file.readByte() // Skip the last byte (
+			println("Offset: $offset, Sector: $sector")
+		}
+
+		return HeaderData(offsets)
+
+	}
+
+	/**
+	 * Convert the name of a region file to a Pair which holds the position.
+	 * E.g.: r.-3.4.mca -> Pair(-3, 4)
+	 */
+	private fun regionPositionFromName(name: String): Pair<Int, Int> {
+		val splitName = name.split('.')
+		return Pair(splitName[1].toInt(), splitName[2].toInt())
+	}
+}

--- a/QuickMCA/src/main/kotlin/mca/IORegion.kt
+++ b/QuickMCA/src/main/kotlin/mca/IORegion.kt
@@ -33,6 +33,7 @@ object IORegion {
 	 * The offset represents the position of the chunk in the file.
 	 * @param file The region file
 	 * @return The header data
+	 * @see <a href="https://minecraft.wiki/w/Region_file_format#Header">Region file format (Header)</a>
 	 */
 	private fun loadHeader(file: RandomAccessFile): HeaderData {
 		// Retrieve chunk offsets

--- a/QuickMCA/src/main/kotlin/mca/IORegion.kt
+++ b/QuickMCA/src/main/kotlin/mca/IORegion.kt
@@ -1,7 +1,6 @@
 package mca
 
 import java.io.File
-import java.io.IOException
 import java.io.RandomAccessFile
 import util.readByteAsInt
 
@@ -9,6 +8,8 @@ import util.readByteAsInt
  * Performs read and write operations of region files (r.X.Y.mca)
  */
 object IORegion {
+	private const val SECTOR_SIZE_BYTE: Int = 4096  // Byte
+	private const val SECTOR_SIZE: Int = SECTOR_SIZE_BYTE / 1024 // KiB
 
 	fun readRegion(regionFile: File): Region {
 		if (regionFile.isDirectory)
@@ -18,41 +19,48 @@ object IORegion {
 
 		val (rPosX, rPosY) = regionPositionFromName(regionFile.name)
 
-		RandomAccessFile(regionFile, "r").use { inputFile ->
-			// --- Get Data from header
-
-			// Retrieve chunk offsets
-			val headerData = loadHeader(inputFile)
+		RandomAccessFile(regionFile, "r").use { file ->
+			// Get Data from header (first 8KiB)
+			val headerData = loadHeader(file)
+			println(headerData)
 		}
-
 
 		return Region(rPosX, rPosY)
 	}
 
-	data class HeaderData(val offset: IntArray)
-
 	/**
-	 * Reads the header of a region file. The header contains the offset of each chunk in the file.
+	 * Reads the header (first 8KiB) of a region file. The header contains the offset of each chunk in the file.
 	 * The offset represents the position of the chunk in the file.
+	 * @param file The region file
+	 * @return The header data
 	 */
 	private fun loadHeader(file: RandomAccessFile): HeaderData {
+		// Retrieve chunk offsets
 		val offsets = IntArray(CHUNKS_IN_REGION)
+		val sectorCounts = ByteArray(CHUNKS_IN_REGION)
+		val timestamps = IntArray(CHUNKS_IN_REGION)
 
-		// Move to beginning of region file
-		file.seek(0)
+		// Header begins at 0
+		file.seek(0L)
 
-		// Read the 1024 chunks, which consist of 4 byte each
+		/* Read the 1024 chunks header data
+		 * Each chunk has 8KiB of data split into two equal sized parts.
+		 * The first chunk contains 3 byte of offset and one for sector
+		 */
 		for(i in offsets.indices) {
+			// Read the first three byte for the offset
 			var offset: Int = file.readByteAsInt() shl 16 // Read and shift 16 bit to the left
 			offset = offset or (file.readByteAsInt() shl 8) // Read and shift 8 bit to the left
-			offsets[i] = offset or (file.readByteAsInt()) // Just rea, no shift
+			offsets[i] = offset or (file.readByteAsInt()) // Just read, no shift
 
-			val sector = file.readByte() // Skip the last byte (
-			println("Offset: $offset, Sector: $sector")
+			// Read 4th byte as sector
+			sectorCounts[i] = file.readByte()
 		}
-
-		return HeaderData(offsets)
-
+		// The second chunk contains a timestamp
+		for (i in offsets.indices) {
+			timestamps[i] = file.readInt()
+		}
+		return HeaderData(offsets, sectorCounts, timestamps)
 	}
 
 	/**
@@ -62,5 +70,41 @@ object IORegion {
 	private fun regionPositionFromName(name: String): Pair<Int, Int> {
 		val splitName = name.split('.')
 		return Pair(splitName[1].toInt(), splitName[2].toInt())
+	}
+}
+
+/**
+ * Holds the data of a region file header
+ */
+private data class HeaderData(
+	val offsets: IntArray,
+	val sectorCounts: ByteArray,
+	val timestamps: IntArray
+) {
+	override fun equals(other: Any?): Boolean {
+		if (this === other) return true
+		if (other !is HeaderData) return false
+
+		if (!offsets.contentEquals(other.offsets) ||
+			!sectorCounts.contentEquals(other.sectorCounts) ||
+			!timestamps.contentEquals(other.timestamps)
+		) return false
+
+		return true
+	}
+
+	override fun hashCode(): Int {
+		var result = offsets.contentHashCode()
+		result = 31 * result + sectorCounts.contentHashCode()
+		result = 31 * result + timestamps.contentHashCode()
+		return result
+	}
+
+	override fun toString(): String {
+		return """
+			Offset: ${offsets.joinToString(", ")}
+			Sector count: ${sectorCounts.joinToString(", ")}
+			Timestamps: ${timestamps.joinToString(", ")}
+		""".trimIndent()
 	}
 }

--- a/QuickMCA/src/main/kotlin/mca/Region.kt
+++ b/QuickMCA/src/main/kotlin/mca/Region.kt
@@ -1,0 +1,37 @@
+package mca
+
+/** Chunks held per dimension */
+const val CHUNKS_PER_REGION_DIM: Byte = 32
+/** Chunks held per region */
+const val CHUNKS_IN_REGION: Int = CHUNKS_PER_REGION_DIM * CHUNKS_PER_REGION_DIM
+
+/**
+ * Stores a block of 32x32 chunks
+ */
+class Region(val posX: Int, val posY: Int) {
+	constructor (position: Pair<Int, Int>): this(position.first, position.second)
+
+	private val chunks = arrayOfNulls<Chunk?>(CHUNKS_IN_REGION)
+
+	operator fun set(chunkPosX: Int, chunkPosY: Int, chunk: Chunk) {
+		chunks[chunkPosX * chunkPosY] = chunk
+	}
+
+	operator fun get(chunkPosX: Int, chunkPosY: Int): Chunk? {
+		return chunks[chunkPosX * chunkPosY]
+	}
+
+	/**
+	 * Provides a comparison of two regions based on their position
+	 * Comparison is based on the X and Y position in a 2D grid like fashion.
+	 * Starting from the top left and moving right. After the row is complete, the next row is started.
+	 */
+	operator fun compareTo(that: Region): Int {
+		val cmpX = this.posX.compareTo(that.posX)
+		return if (cmpX != 0) {
+			cmpX
+		} else {
+			this.posY.compareTo(that.posY)
+		}
+	}
+}

--- a/QuickMCA/src/main/kotlin/util/McaHelper.kt
+++ b/QuickMCA/src/main/kotlin/util/McaHelper.kt
@@ -1,0 +1,8 @@
+package util
+
+import java.io.RandomAccessFile
+
+/**
+ * Reads a byte from the file, and performs a bitwise AND operation with 0xFF.
+ */
+fun RandomAccessFile.readByteAsInt() = this.read() and 0xFF


### PR DESCRIPTION
Read and parse [header](https://minecraft.wiki/w/Region_file_format#Header) of a given minecraft region file.

Offset, the amount of sectors and timestamp of all 1024 (32x32) chunks is retrieved and stored as three base-type arrays